### PR TITLE
fix(deps): pin undici override to 6.28.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "kakunin",
       "version": "0.1.0",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@aws-sdk/client-kms": "^3.1048.0",
@@ -22906,9 +22907,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.1.tgz",
+      "integrity": "sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
     "vitest": "^4.1.6"
   },
   "overrides": {
-    "undici": "^6.27.0"
+    "undici": "6.28.1"
   }
 }


### PR DESCRIPTION
## What
Pins `overrides.undici` to an exact version and moves it from `6.27.0` to `6.28.1`.

## Why
`npm ci` fails on this repo, which is why the `Lint, Type-check & Test` check goes red before it runs a single test:

```
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json or npm-shrinkwrap.json are in sync.
npm error Invalid: lock file's undici@6.27.0 does not satisfy undici@6.28.1
```

The override was a floating range, `"undici": "^6.27.0"`. npm re-resolves override edges against the registry on every `npm ci`, so when undici `6.28.1` published, the edge started demanding `6.28.1` while the lock still pinned `6.27.0`. The two drifted apart and installs stopped working. Nothing in this repo changed — an upstream patch release broke it.

This surfaced now only because CI had not run here in weeks; the scorecard PR triggered the first build in a while.

## Why 6.28.1 and not 6.27.0
Pinning to the lock's existing `6.27.0` would be the smaller change and would fix CI — but `6.27.0` is affected by **GHSA-m8rv-5g2x-5cg5** (medium, patched in `6.28.0`). That would trade a build failure for a silently frozen advisory. `6.28.1` is the latest 6.x and carries the fix.

## Changes
- `package.json` — override `^6.27.0` → `6.28.1`
- `package-lock.json` — undici `6.27.0` → `6.28.1`

The lock diff also picks up a `"license": "AGPL-3.0-only"` line on the root entry. That is npm normalising the lock against `package.json`, not a licensing change; it reappears on any future `npm install`.

## Testing
`npm ci --dry-run` against a clean tree with these exact files:

- before: `EUSAGE`, exit 1
- after: `added` full tree, exit 0

## Risk
Low. Dependency resolution only, no source changes. undici 6.27.0 → 6.28.1 is a patch bump within the same major. Dependabot can still bump the pin deliberately.

## Note
The same floating-range bug exists in the private monorepo and was fixed there today. Unrelated but worth knowing: `jsdom`'s nested `undici@7.28.0` is still within range of the same advisory (patched at `7.29.0`) — dev-only, and the root override does not reach it. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
