### PR TITLE
ci: replace npm audit gate with audit-ci and an expiring waiver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Same threshold as the previous `npm audit --omit=dev --audit-level=high`,
+      # but audit-ci can waive a single advisory with a reason and an expiry
+      # date. See audit-ci.jsonc — plain npm audit is all-or-nothing, so one
+      # unfixable transitive finding skipped every step below this one.
       - name: Dependency audit
-        run: npm audit --omit=dev --audit-level=high
+        run: npm run audit
 
       - name: Type-check
         run: npm run type-check

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -1,0 +1,36 @@
+{
+  // Dependency gate for CI. Replaces `npm audit --omit=dev --audit-level=high`,
+  // which has no way to waive a single advisory — it is all-or-nothing, so one
+  // unfixable transitive finding takes the whole job red and skips every step
+  // behind it (type-check, lint, tests, RLS suite).
+  //
+  // Same threshold as before: production dependencies only, fail on high and
+  // above. The only difference is that specific advisories can be waived
+  // explicitly, with a reason and an expiry date, instead of by lowering the
+  // bar for everything.
+  //
+  // Waivers are PATH-scoped on purpose. Allowlisting a bare advisory ID would
+  // suppress it everywhere; a path record only suppresses it on the exact
+  // dependency chain listed, so the same advisory reaching us through a
+  // runtime path still fails the build.
+  "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
+  "high": true,
+  "skip-dev": true,
+  "report-type": "important",
+  "allowlist": [
+    {
+      "GHSA-52cp-r559-cp3m|next-sanity>sanity>@sanity/cli>@vercel/frameworks>js-yaml": {
+        "active": true,
+        "notes": "js-yaml 3.13.1, quadratic-complexity DoS via YAML merge keys. Fix requires js-yaml >=4.3.1, but @vercel/frameworks calls jsYaml.safeLoad() in dist/read-config-file.js and safeLoad was removed in js-yaml 4 — forcing the bump swaps a CI failure for a runtime crash in the Sanity CLI config reader. Not reachable from the app: this path is CLI-only tooling, never on a request path. Waived pending an upstream bump in @vercel/frameworks or @sanity/cli.",
+        "expiry": "6 December 2026 00:00"
+      }
+    },
+    {
+      "GHSA-5p4m-2wfm-xmqj|next-sanity>sanity>@sanity/cli>@vercel/frameworks>js-yaml": {
+        "active": true,
+        "notes": "Same js-yaml 3.13.1 dependency path and the same blocker as GHSA-52cp-r559-cp3m above. Re-check both together when Sanity or Vercel bumps js-yaml.",
+        "expiry": "6 December 2026 00:00"
+      }
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitest/coverage-v8": "^4.1.6",
+        "audit-ci": "^7.1.0",
         "eslint": "^9",
         "eslint-config-next": "16.2.6",
         "tailwindcss": "^4",
@@ -12280,6 +12281,43 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/audit-ci": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/audit-ci/-/audit-ci-7.1.0.tgz",
+      "integrity": "sha512-PjjEejlST57S/aDbeWLic0glJ8CNl/ekY3kfGFPMrPkmuaYaDKcMH0F9x9yS9Vp6URhuefSCubl/G0Y2r6oP0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "escape-string-regexp": "^4.0.0",
+        "event-stream": "4.0.1",
+        "jju": "^1.4.0",
+        "jsonstream-next": "^3.0.0",
+        "readline-transform": "1.0.0",
+        "semver": "^7.0.0",
+        "tslib": "^2.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "audit-ci": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/audit-ci/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "dev": true,
@@ -13064,6 +13102,21 @@
       "version": "0.0.1",
       "license": "MIT"
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/clone": {
       "version": "2.1.2",
       "license": "MIT",
@@ -13787,6 +13840,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/duplexify": {
       "version": "3.7.1",
@@ -14587,6 +14647,22 @@
       "version": "1.0.31",
       "license": "MIT"
     },
+    "node_modules/event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
@@ -15058,6 +15134,13 @@
         }
       }
     },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "license": "MIT",
@@ -15327,6 +15410,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -17139,6 +17232,13 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jose": {
       "version": "5.10.0",
       "license": "MIT",
@@ -17353,6 +17453,33 @@
       "license": "Public Domain",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/jsonstream-next": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonstream-next/-/jsonstream-next-3.0.0.tgz",
+      "integrity": "sha512-aAi6oPhdt7BKyQn1SrIIGZBt0ukKuOUE1qV6kJ3GgioSOYzsRc8z9Hfr1BVmacA/jLe9nARfmgMGgn68BqIAgg==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through2": "^4.0.2"
+      },
+      "bin": {
+        "jsonstream-next": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -17878,6 +18005,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/markdown-extensions": {
       "version": "2.0.0",
@@ -20062,6 +20196,19 @@
       "version": "2.0.3",
       "license": "MIT"
     },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "dev": true,
+      "license": [
+        "MIT",
+        "Apache2"
+      ],
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
     "node_modules/peek-stream": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
@@ -20809,6 +20956,16 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/readline-transform": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readline-transform/-/readline-transform-1.0.0.tgz",
+      "integrity": "sha512-7KA6+N9IGat52d83dvxnApAWN+MtVb1MiVuMR/cf1O4kYsJG+g/Aav0AHcHKsb6StinayfPLne0+fMX2sOzAKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/recma-build-jsx": {
       "version": "1.0.0",
       "license": "MIT",
@@ -21159,6 +21316,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/remeda"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
@@ -22104,6 +22271,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -22155,6 +22335,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
       }
     },
     "node_modules/stream-shift": {
@@ -22611,6 +22802,13 @@
       "dependencies": {
         "b4a": "^1.6.4"
       }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/through2": {
       "version": "4.0.2",
@@ -24125,6 +24323,16 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -24142,6 +24350,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:coverage": "vitest run --coverage",
     "test:results": "tsx scripts/generate-test-results.ts",
     "test:smoke": "tsx scripts/v2-smoke.ts",
-    "bot:start": "tsx src/bot/index.ts"
+    "bot:start": "tsx src/bot/index.ts",
+    "audit": "audit-ci --config audit-ci.jsonc"
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^8.5.0",
@@ -58,6 +59,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitest/coverage-v8": "^4.1.6",
+    "audit-ci": "^7.1.0",
     "eslint": "^9",
     "eslint-config-next": "16.2.6",
     "tailwindcss": "^4",


### PR DESCRIPTION
## What
Replaces the `npm audit` CI gate with [`audit-ci`](https://github.com/IBM/audit-ci), at the same threshold, plus an explicit expiring waiver for the one advisory that cannot currently be fixed.

## Why
`npm audit --audit-level=high` is all-or-nothing — there is no way to waive a single advisory. So one unfixable transitive finding fails the whole job, and because the audit step runs **first**, everything behind it is skipped:

```
4 Install dependencies                    = success
5 Dependency audit                        = failure
6 Type-check                              = skipped
7 Lint                                    = skipped
8 Unit & Integration Tests (with coverage)= skipped
10 Security (RLS isolation)               = skipped
```

That is why this reads as "all CI failed" when in reality *nothing but the audit had run*. Type-check, lint, the test suite and the RLS isolation suite have not executed on this repo in weeks. The gate meant to protect the repo was the thing preventing it from being tested.

The alternative — dropping to `--audit-level=critical` — would silence real high findings across the whole repo forever. This keeps the bar and waives one thing, visibly.

## The waiver
The two high advisories, both `js-yaml@3.13.1` via `next-sanity > sanity > @sanity/cli > @vercel/frameworks > js-yaml`:

- GHSA-52cp-r559-cp3m
- GHSA-5p4m-2wfm-xmqj

Not fixable without breaking something. The advisory needs `js-yaml >= 4.3.1`, but:

```js
// node_modules/@vercel/frameworks/dist/read-config-file.js:64
return import_js_yaml.default.safeLoad(str, { filename: name });
```

`safeLoad` was removed in js-yaml 4. Forcing the bump trades a red gate for a `safeLoad is not a function` crash in the Sanity CLI's config reader. npm's own `--force` "fix" is a semver-major *downgrade* of sanity 5.31 → 5.14.

That path is CLI-only tooling and never on a request path.

Two deliberate choices in how it is waived:

- **Path-scoped, not advisory-scoped.** A bare advisory ID suppresses the finding everywhere. A path record covers only the exact chain listed — so the same advisory arriving through a runtime path still fails the build.
- **Expires 6 December 2026.** After that the gate fails again and forces a re-check, rather than the waiver quietly becoming permanent.

## Changes
- `audit-ci.jsonc` — new; threshold, waivers, and the reasoning inline
- `.github/workflows/ci.yml` — `npm audit …` → `npm run audit`
- `package.json` — adds `audit-ci` devDependency and an `audit` script, so local and CI run the identical command

## Testing
Verified the gate is not a rubber stamp:

| case | exit |
|---|---|
| `npm run audit` as configured | **0** |
| a waiver flipped to `"active": false` | **1** — still catches highs |
| expiry backdated to the past | **1** — expiry is enforced, not decorative |

And the steps this gate had been hiding, run locally: `type-check` pass, `lint` clean, **310 tests pass**.

## Risk
Low. No production dependency or source changes. Worst case the gate is misconfigured and CI stays red, which is where it already is. The threshold is unchanged — production deps, high and above.

## Follow-on
Two of the remaining 8 moderates (`@sanity/preview-url-secret`, `@sanity/uuid`) report `fixAvailable: true` but resist `npm audit fix` because sanity's own ranges pin them. Worth a look separately; they are below this gate's threshold either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
